### PR TITLE
ZEN-16435: consider all possible daemon not running scenarios.

### DIFF
--- a/ZenPacks/zenoss/OpenvSwitch/objects/objects.xml
+++ b/ZenPacks/zenoss/OpenvSwitch/objects/objects.xml
@@ -136,7 +136,7 @@ ovs_status
 5
 </property>
 <property type="string" id="commandTemplate" mode="w" >
-/bin/echo 'BEGIN' ; /sbin/service openvswitch status 2&gt; /dev/null ; echo "SPLIT" ; /usr/bin/systemctl status openvswitch.service 2&gt; /dev/null ; echo "SPLIT" ; /usr/bin/sudo service openvswitch-switch status 2&gt; /dev/null ; echo "END"
+/bin/echo 'BEGIN' ; /sbin/service openvswitch status 2&gt; /dev/null ; echo "SPLIT" ; /usr/bin/systemctl status openvswitch-nonetwork.service 2&gt; /dev/null ; echo "SPLIT" ; /usr/bin/sudo service openvswitch-switch status 2&gt; /dev/null ; echo "END"
 </property>
 <property type="int" id="cycletime" mode="w" >
 300

--- a/ZenPacks/zenoss/OpenvSwitch/parsers/InterfaceStatus.py
+++ b/ZenPacks/zenoss/OpenvSwitch/parsers/InterfaceStatus.py
@@ -41,6 +41,7 @@ class InterfaceStatus(CommandParser):
 
         # interface admin_state: UP or DOWN
         # interface link_state: UP or DOWN
+        severity = 0
         summary = ''
         iface_stat = [stat for stat in iface_stats if stat['_uuid'] == iface_id]
         if len(iface_stat) == 0:

--- a/monitoring_templates.yaml
+++ b/monitoring_templates.yaml
@@ -222,7 +222,7 @@
 
   datasources:
     openvswitchStatus:
-      commandTemplate: /bin/echo 'BEGIN' ; /sbin/service openvswitch status 2> /dev/null ; echo "SPLIT" ; /usr/bin/systemctl status openvswitch.service 2> /dev/null ; echo "SPLIT" ; /usr/bin/sudo service openvswitch-switch status 2> /dev/null ; echo "END"
+      commandTemplate: /bin/echo 'BEGIN' ; /sbin/service openvswitch status 2> /dev/null ; echo "SPLIT" ; /usr/bin/systemctl status openvswitch-nonetwork.service 2> /dev/null ; echo "SPLIT" ; /usr/bin/sudo service openvswitch-switch status 2> /dev/null ; echo "END"
       cycletime: 300
 
       parser: ZenPacks.zenoss.OpenvSwitch.parsers.OVSStatus


### PR DESCRIPTION
The openvswitch service consists of two daemons: opeb-vswitchd and ovsdb-server. Previously ZP checks the service status as a whole, rather than checking each daemon individually. This commit fixed this problem. On centos 7, "systemctl status openvswitch.service" was replaced by "systemctl status openvswitch-nonetwork.service". Also re-factored OVSStatus.py.
