### PR TITLE
replace add with or and cast wider net to catch error message

### DIFF
--- a/ZenPacks/zenoss/OpenvSwitch/modeler/plugins/zenoss/ssh/OpenvSwitch.py
+++ b/ZenPacks/zenoss/OpenvSwitch/modeler/plugins/zenoss/ssh/OpenvSwitch.py
@@ -44,9 +44,10 @@ class OpenvSwitch(CommandPlugin):
             LOG.error('ovs-vsctl not found on %s', device.id)
             return None
 
-        if  results.find('database connection failed') > -1 and \
-            results.find('No such file or directory') > -1:
-            LOG.info('service openvswitch not running on %s', device.id)
+        if  'database connection failed' in results or \
+                'No such file or directory' in results or \
+                    'connection attempt failed (Connection refused)' in results:
+            LOG.info('service openvswitch or one of its daemons not running on %s', device.id)
             return None
 
         command_strings = results.split('__COMMAND__')


### PR DESCRIPTION
This error message, "Pidfile for ovsdb-server (/var/run/openvswitch/ovsdb-server.pid) is stale", was not caught by previous code. A successful connection should not have any error message in results.
