### PR TITLE
set device monitoring templates to []

### DIFF
--- a/ZenPacks/zenoss/OpenvSwitch/__init__.py
+++ b/ZenPacks/zenoss/OpenvSwitch/__init__.py
@@ -46,7 +46,8 @@ CFG = zenpacklib.ZenPackSpec(
             'zProperties': {
                 'zCollectorPlugins': [
                     'zenoss.ssh.OpenvSwitch',
-                ]
+                ],
+                'zDeviceTemplates':    [],
             }
         }
     },


### PR DESCRIPTION
by default, zenoss will add a device monitoring template, Device, to a device, even though OVS itself does not use any SNMP agent. This on 5.0.2 will generate a SNMP agent DOWN event. This fix removes the default device monitoring template so that zenoss will not generate SNMP event.
