### PR TITLE
process log records without matching component name to allow newly cr…

### DIFF
--- a/ZenPacks/zenoss/OpenvSwitch/parsers/BridgePortStatus.py
+++ b/ZenPacks/zenoss/OpenvSwitch/parsers/BridgePortStatus.py
@@ -60,10 +60,30 @@ class BridgePortStatus(CommandParser):
             if 'del' in evt['summary']:
                 severity = 3
 
+            # the component being added/deleted might not be modeled
+            # yet. In that case, set event component to an empty string
+            component = cmd.component
+            if 'add bridge:' in evt['summary']:
+                bridge_name = evt['summary'][len('add bridge:'):].strip()
+                if bridge_name != component:
+                    component = ''
+            elif 'del bridge:' in evt['summary']:
+                bridge_name = evt['summary'][len('del bridge:'):].strip()
+                if bridge_name != component:
+                    component = ''
+            elif 'add port:' in evt['summary']:
+                port_name = evt['summary'][len('add port:'):].strip()
+                if port_name != component:
+                    component = ''
+            elif 'del port:' in evt['summary']:
+                port_name = evt['summary'][len('del port:'):].strip()
+                if port_name != component:
+                    component = ''
+
             event = dict(
                 summary=evt['summary'],
                 device= cmd.deviceConfig.device,
-                component=cmd.component,
+                component=component,
                 eventClassKey=self.eventClassKey,
                 severity=severity
             )

--- a/ZenPacks/zenoss/OpenvSwitch/utils.py
+++ b/ZenPacks/zenoss/OpenvSwitch/utils.py
@@ -292,10 +292,15 @@ def get_ovsdb_records(logs, component, cycleTime, timedelta):
             # timestamp only, nothing else
             continue
 
+        # by not match records with components, we are able to
+        # display events for newly created bridges, ports
+        # the downside is that we display the same event multiple times.
+        # we have to pick a less bad choice.
+
         # component: bridge name
-        if component not in rcrd:
-            # this record has nothing to do with this bridge
-            continue
+        # if component not in rcrd:
+        #     # this record has nothing to do with this bridge
+        #     continue
 
         if '"ovs-vsctl:' in rcrd:
             marker = min(rcrd.index('"ovs-vsctl:') - 1, len(rcrd))


### PR DESCRIPTION
…eated component events to be displayed

In existing code, we match log records against component name, so that the same log record will be displayed only once. However, that approach will miss those events for not yet modeled components. In this fix we do not match records with component.
