### PR TITLE
ZEN-22790: Switch connection provider to use new Catalog API

### DIFF
--- a/ZenPacks/zenoss/OpenvSwitch/connections_provider.py
+++ b/ZenPacks/zenoss/OpenvSwitch/connections_provider.py
@@ -10,7 +10,7 @@
 from ZenPacks.zenoss.Layer2.connections_provider import \
     Connection, BaseConnectionsProvider
 
-from ZenPacks.zenoss.Layer2.macs_catalog import CatalogAPI as MACsCatalogAPI
+from ZenPacks.zenoss.Layer2.connections_catalog import CatalogAPI
 
 
 class DeviceConnectionsProvider(BaseConnectionsProvider):
@@ -20,7 +20,7 @@ class DeviceConnectionsProvider(BaseConnectionsProvider):
 
     def get_connections(self):
         device = self.context
-        cat = MACsCatalogAPI(device.dmd)
+        cat = CatalogAPI(device.dmd)
 
         # Connect OpenvSwitch to his network by IP
         net = device.dmd.Networks.getNet(device.manageIp)
@@ -37,11 +37,12 @@ class DeviceConnectionsProvider(BaseConnectionsProvider):
                         yield Connection(mac, (device, ), ['layer2', ])
 
                         # Add connections for upstream device(s)
-                        for upstream in cat.get_if_upstream_devices([mac]):
+                        for upstream in cat.get_directly_connected(mac):
                             yield Connection(upstream, (mac, ), ['layer2', ])
                             yield Connection(mac, (upstream, ), ['layer2', ])
 
                         # Add connections for clients
-                        for client in cat.get_if_client_devices([mac]):
+                        for client in cat.get_reverse_connected(mac):
                             yield Connection(client, (mac, ), ['layer2', ])
                             yield Connection(mac, (client, ), ['layer2', ])
+


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-22790

Connection provider used the outdated API to query catalog, which was removed from Layer2 ZP.