### PR TITLE
ZPS-871: No module named connections_catalog causes unusable zenpack

### DIFF
--- a/ZenPacks/zenoss/OpenvSwitch/connections_provider.py
+++ b/ZenPacks/zenoss/OpenvSwitch/connections_provider.py
@@ -10,8 +10,6 @@
 from ZenPacks.zenoss.Layer2.connections_provider import \
     Connection, BaseConnectionsProvider
 
-from ZenPacks.zenoss.Layer2.connections_catalog import CatalogAPI
-
 
 class DeviceConnectionsProvider(BaseConnectionsProvider):
     """
@@ -20,7 +18,6 @@ class DeviceConnectionsProvider(BaseConnectionsProvider):
 
     def get_connections(self):
         device = self.context
-        cat = CatalogAPI(device.dmd)
 
         # Connect OpenvSwitch to his network by IP
         net = device.dmd.Networks.getNet(device.manageIp)
@@ -35,14 +32,4 @@ class DeviceConnectionsProvider(BaseConnectionsProvider):
                         mac = interface.mac.strip()
                         yield Connection(device, (mac, ), ['layer2', ])
                         yield Connection(mac, (device, ), ['layer2', ])
-
-                        # Add connections for upstream device(s)
-                        for upstream in cat.get_directly_connected(mac):
-                            yield Connection(upstream, (mac, ), ['layer2', ])
-                            yield Connection(mac, (upstream, ), ['layer2', ])
-
-                        # Add connections for clients
-                        for client in cat.get_reverse_connected(mac):
-                            yield Connection(client, (mac, ), ['layer2', ])
-                            yield Connection(mac, (client, ), ['layer2', ])
 


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZPS-871

It doesn't make sense to provide connections which are already in Layer2 ZP's catalog.