### PR TITLE
Add '/Devices/' to dcspec.path before removing ZP

### DIFF
--- a/ZenPacks/zenoss/OpenvSwitch/zenpacklib.py
+++ b/ZenPacks/zenoss/OpenvSwitch/zenpacklib.py
@@ -307,8 +307,15 @@ class ZenPack(ZenPackBase):
 
             for dcname, dcspec in self.device_classes.iteritems():
                 if dcspec.remove:
+                    organizerPath = '/Devices/' + dcspec.path.lstrip('/')
+                    try:
+                        app.dmd.Devices.getOrganizer(organizerPath)
+                    except KeyError:
+                        LOG.warning('Unable to remove DeviceClass %s (not found)' % dcspec.path)
+                        continue
+
                     LOG.info('Removing DeviceClass %s' % dcspec.path)
-                    app.dmd.Devices.manage_deleteOrganizer(dcspec.path)
+                    app.dmd.Devices.manage_deleteOrganizer(organizerPath)
 
         super(ZenPack, self).remove(app, leaveObjects=leaveObjects)
 


### PR DESCRIPTION
Fixes ZPS-1301

Add '/Devices/' to dcspec.path before deleting organizer. This allows
dmd to find the correct organizer.