### PR TITLE
BridgePortStatus command parser rework

### DIFF
--- a/ZenPacks/zenoss/OpenvSwitch/parsers/BridgePortStatus.py
+++ b/ZenPacks/zenoss/OpenvSwitch/parsers/BridgePortStatus.py
@@ -20,7 +20,7 @@ import logging
 log = logging.getLogger('zen.OpenvSwitch.Parser')
 
 from Products.ZenRRD.CommandParser import CommandParser
-from ZenPacks.zenoss.OpenvSwitch.utils import str_to_dict, get_ovsdb_records
+from ZenPacks.zenoss.OpenvSwitch.utils import get_ovsdb_records, ovsdb_records_to_dict
 
 class BridgePortStatus(CommandParser):
 
@@ -44,7 +44,7 @@ class BridgePortStatus(CommandParser):
         localepoch = calendar.timegm(time.gmtime())
         timedelta = localepoch - int(ovsepoch)
 
-        logs = str_to_dict(cmd.result.output.split('SPLIT')[2])
+        logs = ovsdb_records_to_dict(cmd.result.output.split('SPLIT')[2])
         # logs[0] looks like:
         # {'record 0': 'Open_vSwitch" schema, version="7.4.0", cksum="951746691 20389'}
         # logs[1] is more interesting. Haven't seen logs[2] yet
@@ -54,7 +54,7 @@ class BridgePortStatus(CommandParser):
         # record time supposed to be UTC time
         # We assume the time string looks like: 2015-01-29 05:20:30.199
 
-        events = get_ovsdb_records(logs[1], cmd.component, cmd.cycleTime, timedelta)
+        events = get_ovsdb_records(logs, cmd.component, cmd.cycleTime, timedelta)
         for evt in events:
             severity = 2
             if 'del' in evt['summary']:

--- a/ZenPacks/zenoss/OpenvSwitch/tests/data/bridge_port_status.txt
+++ b/ZenPacks/zenoss/OpenvSwitch/tests/data/bridge_port_status.txt
@@ -59,7 +59,14 @@ record 16: 2015-02-05 07:33:16.350
 record 17: 2015-02-05 07:33:19.284 "ovs-vsctl: /bin/ovs-vsctl --timeout=10 set Port tap9142c144-08 tag=1"
 record 18: 2015-02-05 07:33:19.284
 record 19: 2022-05-26 05:08:57.600 "ovs-vsctl (invoked by /usr/bin/python2): ovs-vsctl --timeout=120 -- --may-exist add-port br-int qvo9fd95ae8-20 -- set Interface qvo9fd95ae8-20 external-ids:iface-id=9fd95ae8-207b-4052-a9a9-5ac77be051bf external-ids:iface-status=active external-ids:attached-mac=fa:16:3e:43:f8:78 external-ids:vm-uuid=12dd1985-c9c4-4333-9ccb-cae2d5db4520"
-record 20: 2015-02-05 15:33:19.579
-record 21: 2020-04-16 14:00:15.094 "ovs-vsctl (invoked by /bin/bash): /usr/bin/ovs-vsctl --no-wait set Open_vSwitch . other_config:pmd-cpu-mask=0x600006"
-record 22: 2019-01-30 10:53:17.481 "ovs-vsctl (invoked by /bin/sh): ovs-vsctl --no-wait -- init -- set Open_vSwitch . db-version=7.15.1"
-record 23: 2015-02-05 07:45:19.579
+record 20: 2019-01-30 10:53:30.156 "ovs-vsctl (invoked by /usr/bin/ruby): /usr/bin/ovs-vsctl add-br br-ex"
+record 21: 2015-02-05 15:33:19.579
+record 22: 2020-04-16 14:00:15.094 "ovs-vsctl (invoked by /bin/bash): /usr/bin/ovs-vsctl --no-wait set Open_vSwitch . other_config:pmd-cpu-mask=0x600006"
+record 23: 2019-01-30 10:53:17.481 "ovs-vsctl (invoked by /bin/sh): ovs-vsctl --no-wait -- init -- set Open_vSwitch . db-version=7.15.1"
+record 24: 2015-02-05 07:45:19.579
+record 25: 2022-07-01 07:14:46.650 "compacting database online"
+record 26: 2021-11-10 13:05:57.114 "Port: Deleting tun0caf747eca7 attached to br-int
+Bridge: Mutating br-int to remove port 193153a3-1375-44d6-be4c-2ce72649de45"
+record 27: 2018-02-05 07:45:19.579
+record 28: 2021-11-10 13:05:57.114 "Port: Deleting tun0caf747eca7 attached to br-int
+Bridge: Mutating br-int to remove port 193153a3-1375-44d6-be4c-2ce72649de45"

--- a/ZenPacks/zenoss/OpenvSwitch/utils.py
+++ b/ZenPacks/zenoss/OpenvSwitch/utils.py
@@ -85,7 +85,8 @@ def ovsdb_records_to_dict(raw_log):
     ovsdb_records_dict = {}
     for record in cleared_output:
         pair = record.split(':', 1)
-        ovsdb_records_dict[pair[0].strip()] = localparser(pair[1].strip())
+        if len(pair) == 2:
+            ovsdb_records_dict[pair[0].strip()] = localparser(pair[1].strip())
 
     return ovsdb_records_dict
 

--- a/ZenPacks/zenoss/OpenvSwitch/utils.py
+++ b/ZenPacks/zenoss/OpenvSwitch/utils.py
@@ -71,6 +71,25 @@ def str_to_dict(original):
     return rets
 
 
+def ovsdb_records_to_dict(raw_log):
+    split_output = raw_log.strip().split('\n')
+    # Format command output to following example
+    # Each line should look like: <record_number>: <record_epoch> "<record_content>"
+    cleared_output = []
+    for line in split_output:
+        if line.startswith('record'):
+            cleared_output.append(line)
+        else:
+            cleared_output[-1] = "{} {}".format(cleared_output[-1], line)
+
+    ovsdb_records_dict = {}
+    for record in cleared_output:
+        pair = record.split(':', 1)
+        ovsdb_records_dict[pair[0].strip()] = localparser(pair[1].strip())
+
+    return ovsdb_records_dict
+
+
 def localparser(text):
     text = text.strip()
 
@@ -287,8 +306,8 @@ def get_ovsdb_records(logs, component, cycleTime, timedelta):
     recordpattern2 = '%Y-%m-%d %H:%M:%S.%f'  # for '2015-03-10 08:35:31.xxx'
 
     records = []
-    rcrd_index = len(logs)
-    while rcrd_index > 0:
+    rcrd_index = len(logs) - 1
+    while rcrd_index >= 0:
 
         item = {}
         rcrd_title = 'record ' + str(rcrd_index)


### PR DESCRIPTION
Fixes ZPS-8232.

Fixed cases where BridgePortStatus command output
has lines with unexpected line breaks which is causing
the tracebacks in zencommand log.